### PR TITLE
Update Contact getquick

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3478,7 +3478,7 @@ WHERE  $smartGroupClause
     // Replace spaces with wildcards for a LIKE operation
     // UNLESS string contains a comma (this exception is a tiny bit questionable)
     // Also need to check if there is space in between sort name.
-    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE && strpos($value, ' ') === TRUE) {
+    elseif ($op == 'LIKE' && strpos($value, ',') === FALSE && strpos($value, ' ') !== FALSE) {
       $value = str_replace(' ', '%', $value);
     }
     $value = CRM_Core_DAO::escapeString(trim($value));

--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -945,6 +945,10 @@ function civicrm_api3_contact_getquick($params) {
   else {
     $strSearch = "$name%";
   }
+  // Replace space to allow to search for full name
+  if ( strpos($strSearch, ',') === FALSE && strpos($strSearch, ' ') !== FALSE ){
+    $strSearch = str_replace(' ','%',$strSearch);
+  }
   $includeEmailFrom = $includeNickName = '';
   if ($config->includeNickNameInName) {
     $includeNickName = " OR nick_name LIKE '$strSearch'";


### PR DESCRIPTION
Allow to search for fullname on Contact getquick

Overview
----------------------------------------
Allow to search by full name by replacing spaces with wildcard in the search term.

Before
----------------------------------------
Getquick would return no results when searching for {first_name} {last_name}.

After
----------------------------------------
Getquick returns results when searching for {first_name} {last_name}.

Technical Details
----------------------------------------
Replicated what we are doing in the Contact/Query: if there is no comma (','), we replace spaces (' ') with the wildcard ('%').

Comments
----------------------------------------
Untested if this affects when searching for other fields.
